### PR TITLE
Add bash

### DIFF
--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,6 +1,6 @@
 FROM elixir:1.6-alpine
 
-RUN apk add nodejs-npm curl yarn
+RUN apk add nodejs-npm curl yarn bash
 
 # Install app dependencies
 RUN mix local.hex --force


### PR DESCRIPTION
La raison c’est que clever-cloud invoque bash quand on fait un `clever ssh`