### PR TITLE
Mise à jour Elixir, Erlang et NodeJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ cd transport-site
 docker build . -t test:latest
 docker run -it --rm test:latest /bin/bash -c 'node --version'
 docker run -it --rm test:latest /bin/bash -c 'elixir --version'
-docker run -it --rm test:latest /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
+docker run -it --rm test:latest /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
 ```

--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ The _Transport Site_ project is tested with CircleCI in a Docker container that 
 When updating that Dockerfile, push a git tag in the format `a.b.c` and the image will be built by Dockerhub : https://hub.docker.com/r/betagouv/transport/
 
 Then update https://github.com/etalab/transport-site/blob/master/.circleci/config.yml to match the new version.
+
+## Useful tricks when upgrading
+
+Before creating a tag, the following commands can be used to verify the versions:
+
+```
+cd transport-site
+docker build . -t test:latest
+docker run -it --rm test:latest /bin/bash -c 'node --version'
+docker run -it --rm test:latest /bin/bash -c 'elixir --version'
+docker run -it --rm test:latest /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'
+```

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,4 +1,5 @@
-FROM elixir:1.8-alpine
+# see https://hub.docker.com/_/elixir
+FROM elixir:1.10.4-alpine
 
 RUN apk add nodejs-npm curl yarn bash build-base wget libtool
 


### PR DESCRIPTION
Je travaille sur https://github.com/etalab/transport-site/pull/1363 et je vais avoir besoin de créer une nouvelle image avec des versions plus récentes.

Je note que j'obtiens les versions suivantes:

```
$ docker run -it --rm test:latest /bin/bash -c 'node --version'
v12.15.0

$ docker run -it --rm test:latest /bin/bash -c 'elixir --version'
Erlang/OTP 22 [erts-10.7.2.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]

Elixir 1.10.4 (compiled with Erlang/OTP 22)

$ docker run -it --rm test:latest /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
"Erlang/OTP 22 [erts-10.7.2.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]\n"
```

On remarque que Node fait un joli saut de 10 à 12 aussi.

Après vérification, on mergera pour que je tente de créer un tag et voir si la build s'enclenche sur Docker.