### PR TITLE
Mise à jour Elixir, Erlang et NodeJS (+ ajout git)

### DIFF
--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,5 +1,5 @@
 # see https://hub.docker.com/_/elixir
-FROM elixir:1.10.4-alpine
+FROM elixir:1.11.3-alpine
 
 RUN apk add nodejs-npm curl yarn bash build-base wget libtool git
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -7,6 +7,8 @@ RUN apk add nodejs-npm curl yarn bash build-base wget libtool git
 RUN mix local.hex --force
 RUN mix local.rebar --force
 
+# NOTE: development at https://git.savannah.gnu.org/gitweb/?p=libiconv.git
+# and publication at https://ftp.gnu.org/pub/gnu/libiconv
 RUN wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz
 RUN tar -xf libiconv-1.16.tar.gz
 RUN cd libiconv-1.16 && ./configure --prefix= && make && make install

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,7 +1,7 @@
 # see https://hub.docker.com/_/elixir
 FROM elixir:1.10.4-alpine
 
-RUN apk add nodejs-npm curl yarn bash build-base wget libtool
+RUN apk add nodejs-npm curl yarn bash build-base wget libtool git
 
 # Install app dependencies
 RUN mix local.hex --force


### PR DESCRIPTION
Cette PR apporte les mises à jour suivantes:
- Elixir 1.11.3
- OTP 23 (amené par défaut)
- NodeJS v14.15.5 (dernière LTS)

J'ai suivi les notes ajoutées au readme via #18 pour construire, vérifier et publier une nouvelle [image betagouv/transport:0.5.0 sur docker hub](https://hub.docker.com/layers/138250086/betagouv/transport/0.5.0/images).

Je vais créer une release ici après le merge pour suivre ce point, en attendant de mettre en place un processus de construction automatique.