### PR TITLE
Passage à OTP 23 et amélioration de l'image transport

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+task :get_image_version do
+  version = IO.read("transport-site/Dockerfile")[/FROM (hexpm\/elixir.*)/, 1]
+  version = version.gsub('hexpm/elixir:','elixir-')
+  fail "Unexpected FROM format, script must be verified" unless version =~ /\Aelixir\-[^\-]+\-erlang\-[^\-]+\-alpine\-[^\-]+\z/
+  puts version
+end

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,6 +1,8 @@
 # see https://hub.docker.com/r/hexpm/elixir
 FROM hexpm/elixir:1.10.4-erlang-23.2.7.2-alpine-3.13.3
 
+# TODO: iconv could probably be removed later 
+# https://github.com/etalab/transport-site/issues/1591
 RUN apk add curl bash build-base wget libtool git gnu-libiconv
 
 # To be removed in favor of multistage build with deterministic version numbers,

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,5 +1,5 @@
-# see https://hub.docker.com/_/elixir
-FROM elixir:1.11.3-alpine
+# see https://hub.docker.com/r/hexpm/elixir
+FROM hexpm/elixir:1.10.4-erlang-23.2.7.2-alpine-3.13.3
 
 RUN apk add nodejs-npm curl yarn bash build-base wget libtool git
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,7 +1,7 @@
 # see https://hub.docker.com/r/hexpm/elixir
 FROM hexpm/elixir:1.10.4-erlang-23.2.7.2-alpine-3.13.3
 
-RUN apk add curl bash build-base wget libtool git
+RUN apk add curl bash build-base wget libtool git gnu-libiconv
 
 # To be removed in favor of multistage build with deterministic version numbers,
 # e.g. https://dev.to/quatermain/comment/njf7
@@ -10,12 +10,3 @@ RUN apk add nodejs-npm yarn
 # Install app dependencies
 RUN mix local.hex --force
 RUN mix local.rebar --force
-
-# NOTE: development at https://git.savannah.gnu.org/gitweb/?p=libiconv.git
-# and publication at https://ftp.gnu.org/pub/gnu/libiconv
-RUN wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz
-RUN tar -xf libiconv-1.16.tar.gz
-RUN cd libiconv-1.16 && ./configure --prefix= && make && make install
-RUN libtool --finish /lib
-RUN rm libiconv-1.16.tar.gz
-RUN rm -r libiconv-1.16

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,7 +1,11 @@
 # see https://hub.docker.com/r/hexpm/elixir
 FROM hexpm/elixir:1.10.4-erlang-23.2.7.2-alpine-3.13.3
 
-RUN apk add nodejs-npm curl yarn bash build-base wget libtool git
+RUN apk add curl bash build-base wget libtool git
+
+# To be removed in favor of multistage build with deterministic version numbers,
+# e.g. https://dev.to/quatermain/comment/njf7
+RUN apk add nodejs-npm yarn
 
 # Install app dependencies
 RUN mix local.hex --force


### PR DESCRIPTION
Je suis en train de mettre à jour OTP de 22 à 23 (https://github.com/etalab/transport-site/pull/1590), et je souhaite faire cela sans mettre à jour Elixir (mise à jour qui nécessitera, elle, davantage de travail).

Comme expliqué dans #21, je bascule l'image de base de https://hub.docker.com/_/elixir vers https://github.com/hexpm/bob#docker-images, car ces dernières me permettent de décider quelle version d'OTP je souhaite, et d'upgrader ainsi uniquement OTP et pas Elixir.

Par ailleurs je remplace une compilation de iconv par l'installation d'un package, et j'améliore la documentation.