### PR TITLE
Mise à jour Elixir 1.10 -> 1.12 et OTP 23 -> 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Now we name them after the Elixir, Erlang and Alpine versions actually used (lik
 * Replace `hexpm/elixir:` by `betagouv/transport:elixir-`
 * Target name: `betagouv/transport:elixir-1.10.4-erlang-23.2.7.2-alpine-3.13.3`
 
-You can use `rake get_image_name` to build the expected target name out of the `Dockerfile` in automated fashion.
+You can use `rake get_image_version` to build the expected target name out of the `Dockerfile` in automated fashion.
 
 ## Production configuration and deployment
 
@@ -49,7 +49,7 @@ As a work-around for [#17](https://github.com/etalab/transport-ops/issues/17):
 ```
 IMAGE_VERSION=$(rake get_image_version)
 IMAGE_NAME=betagouv/transport:$IMAGE_VERSION
-docker build transport-site --no-cache -t $IMAGE_VERSION
+docker build transport-site --no-cache -t $IMAGE_NAME
 ```
 
 * Carefully verify the versions (this will be translated into a testing script later):

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,5 +1,5 @@
 # see https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.12.1-erlang-23.3.4.4-alpine-3.13.3
+FROM hexpm/elixir:1.12.1-erlang-24.0.3-alpine-3.13.3
 
 # TODO: iconv could probably be removed later 
 # https://github.com/etalab/transport-site/issues/1591

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,5 +1,5 @@
 # see https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.10.4-erlang-23.2.7.2-alpine-3.13.3
+FROM hexpm/elixir:1.12.1-erlang-23.3.4.4-alpine-3.13.3
 
 # TODO: iconv could probably be removed later 
 # https://github.com/etalab/transport-site/issues/1591


### PR DESCRIPTION
On va tester cette release tranquillement sur le staging, je la crée ici pour pouvoir la référencer.