### PR TITLE
Mise à jour Elixir 1.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ docker run -it --rm $IMAGE_NAME /bin/bash -c "erl -noshell -eval 'erlang:display
 * List the local images with `docker image ls`
 * Filter with `docker image ls | grep "betagouv/transport" | grep $IMAGE_VERSION`
 * Push with `docker image push $IMAGE_NAME`
+* Verify tag presence at https://hub.docker.com/repository/docker/betagouv/transport
 * TODO: handle `latest` (but it is currently unused)
 
 ## Useful tricks when upgrading

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,4 +1,15 @@
-# see https://hub.docker.com/r/hexpm/elixir
+# We leverage the base images published by hexpm.
+#
+# https://hub.docker.com/r/hexpm/elixir
+#
+# They provide the ability to decouple Elixir version
+# and OTP version, which is a nice feature for
+# incremental/decoupled upgrades.
+#
+# These base images package Elixir and OTP releases found at:
+# - https://github.com/elixir-lang/elixir/releases
+# - https://github.com/erlang/otp/releases
+#
 FROM hexpm/elixir:1.12.1-erlang-24.0.3-alpine-3.13.3
 
 # TODO: iconv could probably be removed later 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -10,7 +10,7 @@
 # - https://github.com/elixir-lang/elixir/releases
 # - https://github.com/erlang/otp/releases
 #
-FROM hexpm/elixir:1.12.1-erlang-24.0.3-alpine-3.13.3
+FROM hexpm/elixir:1.12.2-erlang-24.0.3-alpine-3.13.3
 
 # TODO: iconv could probably be removed later 
 # https://github.com/etalab/transport-site/issues/1591


### PR DESCRIPTION
Avant de faire le premier déploiement en Elixir 1.12, je mets à jour à la toute dernière version qui vient de sortir.

Je l'ai pushé sur https://hub.docker.com/repository/docker/betagouv/transport.

Note: j'ai amélioré un peu le readme histoire de nous retrouver vaguement un peu plus, ça mériterait un ménage complet, mais probablement après avoir solutionné #17.