### PR TITLE
Alpine to ubuntu move

### DIFF
--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -30,9 +30,7 @@ ENV NVM_DIR $HOME/.nvm
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
 # Install NODE ("." is the sh equivalent to the bash "source" command)
-RUN . $NVM_DIR/nvm.sh; \
-    nvm install $NODE_VERSION; \
-    nvm use --delete-prefix $NODE_VERSION;
+RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION
 
 # add to path
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -10,7 +10,7 @@
 # - https://github.com/elixir-lang/elixir/releases
 # - https://github.com/erlang/otp/releases
 #
-FROM hexpm/elixir:1.12.2-erlang-24.0.3-focal-20210325
+FROM hexpm/elixir:1.12.2-erlang-24.0.3-ubuntu-focal-20210325
 
 # TODO: iconv could probably be removed later 
 # https://github.com/etalab/transport-site/issues/1591

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -10,7 +10,7 @@
 # - https://github.com/elixir-lang/elixir/releases
 # - https://github.com/erlang/otp/releases
 #
-FROM hexpm/elixir:1.12.2-erlang-24.0.3-ubuntu-focal-20210325
+FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -12,13 +12,20 @@
 #
 FROM hexpm/elixir:1.12.2-erlang-24.0.3-ubuntu-focal-20210325
 
-# TODO: iconv could probably be removed later 
-# https://github.com/etalab/transport-site/issues/1591
-RUN apk add curl bash build-base wget libtool git gnu-libiconv
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Paris
+RUN apt-get install -y tzdata
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    libtool \
+    git
 
 # To be removed in favor of multistage build with deterministic version numbers,
 # e.g. https://dev.to/quatermain/comment/njf7
-RUN apk add nodejs-npm yarn
+RUN apt-get install -y nodejs npm
+RUN npm install -g yarn
 
 # Install app dependencies
 RUN mix local.hex --force

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -26,14 +26,11 @@ ENV NVM_VERSION v0.29.0
 ENV NODE_VERSION 14.16.1
 ENV NVM_DIR $HOME/.nvm
 
-# Replace shell with bash so we can source files
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
-# Install NODE
-RUN source $NVM_DIR/nvm.sh; \
+# Install NODE ("." is the sh equivalent to the bash "source" command)
+RUN . $NVM_DIR/nvm.sh; \
     nvm install $NODE_VERSION; \
     nvm use --delete-prefix $NODE_VERSION;
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -22,9 +22,25 @@ RUN apt-get update && apt-get install -y \
     libtool \
     git
 
-# To be removed in favor of multistage build with deterministic version numbers,
-# e.g. https://dev.to/quatermain/comment/njf7
-RUN apt-get install -y nodejs npm
+ENV NVM_VERSION v0.29.0
+ENV NODE_VERSION 14.16.1
+ENV NVM_DIR $HOME/.nvm
+
+# Replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Install NVM
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+
+# Install NODE
+RUN source $NVM_DIR/nvm.sh; \
+    nvm install $NODE_VERSION; \
+    nvm use --delete-prefix $NODE_VERSION;
+
+# add to path
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
 RUN npm install -g yarn
 
 # Install app dependencies


### PR DESCRIPTION
Adaptation du dockerfile pour qu'il fonctionne avec Ubuntu.

J'ai installé node avec nvm afin de pouvoir controler la version, parce que je me faisais bouler dans les tests du CI de transport-site.

J'installe yarn depuis npm, ce qui a l'air d'être le plus pratique sous ubuntu.

J'ai buildé et pushé cette branche sur docker hub sous le tag `elixir-1.12.2-erlang-24.0.4-ubuntu-focal-20210325`. https://hub.docker.com/r/betagouv/transport/tags?page=1&ordering=last_updated

J'ai également mis à jour OTP au passage pour le passer à la version 24.0.4.