### PR TITLE
Fix docker build

### DIFF
--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -18,6 +18,9 @@ FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris
+
+RUN apt-get update
+
 RUN apt-get install -y tzdata
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
J'ai une série d'erreurs lors du build de l'image Docker.

La 1ère est sur la récupération de la librairie `tzdata` via apt-get.
La 2ème est sur l'installation de nodejs via NVM (http 404).

### RUN apt-get install -y tzdata échoue suite à une erreur HTTP 404 
```
▶ docker build . -t td_ops
[+] Building 2.4s (8/17)                                                                                                                                                                                                                                                                                                
=> [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                               0.0s
=> => transferring dockerfile: 1.52kB                                                                                                                                                                                                                                                                             0.0s
=> [internal] load .dockerignore                                                                                                                                                                                                                                                                                  0.0s
=> => transferring context: 2B                                                                                                                                                                                                                                                                                    0.0s
=> [internal] load metadata for docker.io/hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325                                                                                                                                                                                                                 1.1s
=> [internal] load metadata for ghcr.io/etalab/transport-tools:master                                                                                                                                                                                                                                             1.0s
=> [auth] hexpm/elixir:pull token for registry-1.docker.io                                                                                                                                                                                                                                                        0.0s
=> CACHED [stage-1  1/11] FROM docker.io/hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325@sha256:95a6193b160b850eb5a5eaa2edc2735ba34a3cfa293aa21ecc24cba4556ef321                                                                                                                                          0.0s
=> CACHED [transport-tools 1/1] FROM ghcr.io/etalab/transport-tools:master@sha256:d3b86666776d3be59079ccdd0623fb4f1c42c92ee6dbf4c07b26fb7917b70be4                                                                                                                                                                0.0s
=> ERROR [stage-1  2/11] RUN apt-get install -y tzdata                                                                                                                                                                                                                                                            1.2s
------                                                                                                                                                                                                                                                                                                                  
> [stage-1  2/11] RUN apt-get install -y tzdata:
#7 0.226 Reading package lists...
#7 0.606 Building dependency tree...
#7 0.693 Reading state information...
#7 0.791 The following NEW packages will be installed:
#7 0.791   tzdata
#7 1.088 0 upgraded, 1 newly installed, 0 to remove and 18 not upgraded.
#7 1.088 Need to get 295 kB of archives.
#7 1.088 After this operation, 4033 kB of additional disk space will be used.
#7 1.088 Ign:1 http://ports.ubuntu.com/ubuntu-ports focal-updates/main arm64 tzdata all 2021a-0ubuntu0.20.04
#7 1.197 Err:1 http://ports.ubuntu.com/ubuntu-ports focal-updates/main arm64 tzdata all 2021a-0ubuntu0.20.04
#7 1.197   404  Not Found [IP: 91.189.91.38 80]
#7 1.220 E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/t/tzdata/tzdata_2021a-0ubuntu0.20.04_all.deb  404  Not Found [IP: 91.189.91.38 80]
#7 1.220 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
------
executor failed running [/bin/sh -c apt-get install -y tzdata]: exit code: 100
```

### RUN . /.nvm/nvm.sh && nvm install 14.16.1 && nvm use --delete-prefix 14.16.1 échoue suite à une erreur HTTP 404
```
▶ docker build . -t td_ops
[+] Building 2.8s (12/18)                                                                                                                                                                                                                                                                                               
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                               0.0s
 => => transferring dockerfile: 1.54kB                                                                                                                                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325                                                                                                                                                                                                                 1.2s
 => [internal] load metadata for ghcr.io/etalab/transport-tools:master                                                                                                                                                                                                                                             0.4s
 => [auth] hexpm/elixir:pull token for registry-1.docker.io                                                                                                                                                                                                                                                        0.0s
 => CACHED [transport-tools 1/1] FROM ghcr.io/etalab/transport-tools:master@sha256:d3b86666776d3be59079ccdd0623fb4f1c42c92ee6dbf4c07b26fb7917b70be4                                                                                                                                                                0.0s
 => [stage-1  1/12] FROM docker.io/hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325@sha256:95a6193b160b850eb5a5eaa2edc2735ba34a3cfa293aa21ecc24cba4556ef321                                                                                                                                                 0.0s
 => CACHED [stage-1  2/12] RUN apt-get update                                                                                                                                                                                                                                                                      0.0s
 => CACHED [stage-1  3/12] RUN apt-get install -y tzdata                                                                                                                                                                                                                                                           0.0s
 => CACHED [stage-1  4/12] RUN apt-get update && apt-get install -y     curl     wget     libtool     git                                                                                                                                                                                                          0.0s
 => CACHED [stage-1  5/12] RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash                                                                                                                                                                                                 0.0s
 => ERROR [stage-1  6/12] RUN . /.nvm/nvm.sh && nvm install 14.16.1 && nvm use --delete-prefix 14.16.1                                                                                                                                                                                                             1.5s
------                                                                                                                                                                                                                                                                                                                  
 > [stage-1  6/12] RUN . /.nvm/nvm.sh && nvm install 14.16.1 && nvm use --delete-prefix 14.16.1:                                                                                                                                                                                                                        
#11 1.062 Downloading https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-aarch64.tar.gz...                                                                                                                                                                                                                            
#11 1.241 #=#=#                                                                                                                                                                                                                                                                                                         
#11 1.245 WARNING: checksums are currently disabled for node.js v4.0 and later                                                                                                                                                                                                                                          
#11 1.249                                                                                                                                                                                                                                                                                                               
#11 1.249 gzip: stdin: not in gzip format
#11 1.249 tar: Child returned status 1
#11 1.249 tar: Error is not recoverable: exiting now
#11 1.250 Binary download failed, trying source.
#11 1.488 
#11 1.494 Checksums empty
#11 1.496 
#11 1.496 gzip: stdin: not in gzip format
#11 1.496 tar: Child returned status 1
#11 1.496 tar: Error is not recoverable: exiting now
#11 1.497 Binary download failed, trying source.
#11 1.498 Installing node v1.0 and greater from source is not currently supported
------
executor failed running [/bin/sh -c . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION]: exit code: 106
```

### Todo

- [X] Corriger installation tzdata
- [ ] Corriger installation nodejs