### PR TITLE
Correction installation tzdata + début d'ajout d'outils de test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,67 @@
+# Inspiration:
+# - https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages
+# - https://github.com/docker/build-push-action/blob/master/docs/advanced/test-before-push.md
+name: Test the docker image
+on:
+  # TODO: publish 1/ "master" for each "master" merged PR
+  # then 2/ for each "release". This will let us iterate
+  # without consequences, and control the moment when we want to tag & ship.
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  TEST_TAG: ${{ github.repository }}:test
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # See https://github.com/docker/build-push-action/blob/master/docs/advanced/test-before-push.md
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
+
+      # https://github.com/docker/login-action
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
+        with:
+          context: .
+          # "load: true" apparently exports the image on the client (no external push),
+          # which is useful for testing it before any push.
+          # see https://github.com/docker/build-push-action
+          # --output=type=docker to enforce local work
+          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#load
+          # https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#docker
+          load: true 
+          push: false # the default, but added for clarity
+          tags: ${{ env.TEST_TAG }}
+
+      - name: Test
+        run: |
+          # TODO: assert 
+          docker run -it --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version'
+          docker run -it --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version'
+          docker run -it --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
+
+      # TODO: handle testing then publication using:
+      # - https://github.com/etalab/transport-ops/issues/30
+      # - https://github.com/etalab/transport-tools/blob/master/.github/workflows/docker.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Test
         run: |
-          # TODO: assert 
+          set -e
           docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep -q 'v14.16.0' && echo 'matched'
           docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep -q 'Elixir 1.12.2 (compiled with Erlang/OTP 24)' && echo 'matched'
           docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,3 +65,6 @@ jobs:
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30
       # - https://github.com/etalab/transport-tools/blob/master/.github/workflows/docker.yml
+      
+      # TODO: consider caching
+      # - https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,13 +60,13 @@ jobs:
 
       # NOTE: the following tests rely on grep exit code (0 if match found)
       - name: Test that Node can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep '${{ env.TEST_EXPECTED_NODE_OUTPUT }}'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep ${{ env.TEST_EXPECTED_NODE_OUTPUT }}
       
       - name: Test that Elixir can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep '$${ env.TEST_EXPECTED_ELIXIR_OUTPUT }}'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep $${ env.TEST_EXPECTED_ELIXIR_OUTPUT }}
 
       - name: Test that Erlang can start and has (major) expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep '$${ env.TEST_EXPECTED_ERLANG_OUTPUT }}'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep $${ env.TEST_EXPECTED_ERLANG_OUTPUT }}
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,7 @@ jobs:
         run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep 'Elixir 1.12.2 (compiled with Erlang/OTP 24)'
 
       - name: Test that Erlang can start and has (major) expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep 'Erlang/OTP 22'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep 'Erlang/OTP 24'
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,10 +63,10 @@ jobs:
         run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep ${{ env.TEST_EXPECTED_NODE_OUTPUT }}
       
       - name: Test that Elixir can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep ${ env.TEST_EXPECTED_ELIXIR_OUTPUT }}
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep ${{ env.TEST_EXPECTED_ELIXIR_OUTPUT }}
 
       - name: Test that Erlang can start and has (major) expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep ${ env.TEST_EXPECTED_ERLANG_OUTPUT }}
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep ${{ env.TEST_EXPECTED_ERLANG_OUTPUT }}
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,13 +60,13 @@ jobs:
 
       # NOTE: the following tests rely on grep exit code (0 if match found)
       - name: Test that Node can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep ${{ env.TEST_EXPECTED_NODE_OUTPUT }}
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep '${{ env.TEST_EXPECTED_NODE_OUTPUT }}'
       
       - name: Test that Elixir can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep ${{ env.TEST_EXPECTED_ELIXIR_OUTPUT }}
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep '${{ env.TEST_EXPECTED_ELIXIR_OUTPUT }}'
 
       - name: Test that Erlang can start and has (major) expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep ${{ env.TEST_EXPECTED_ERLANG_OUTPUT }}
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep '${{ env.TEST_EXPECTED_ERLANG_OUTPUT }}'
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Test
         run: |
           # TODO: assert 
-          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version'
-          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version'
+          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep -q 'v14.16.0' && echo 'matched'
+          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep -q 'Elixir 1.12.2 (compiled with Erlang/OTP 24)' && echo 'matched'
           docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
 
       # TODO: handle testing then publication using:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
 
       # NOTE: the following tests rely on grep exit code (0 if match found)
       - name: Test that Node can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep 'v14.16.0'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep 'v14.16.1'
       
       - name: Test that Elixir can start and has expected version
         run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep 'Elixir 1.12.0 (compiled with Erlang/OTP 24)'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,12 +55,15 @@ jobs:
           push: false # the default, but added for clarity
           tags: ${{ env.TEST_TAG }}
 
-      - name: Test
-        run: |
-          set -e
-          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep -q 'v14.16.0' && echo 'matched'
-          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep -q 'Elixir 1.12.2 (compiled with Erlang/OTP 24)' && echo 'matched'
-          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
+      # NOTE: the following tests rely on grep exit code (0 if match found)
+      - name: Test that Node can start and has expected version
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep 'v14.16.0'
+      
+      - name: Test that Elixir can start and has expected version
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep 'Elixir 1.12.0 (compiled with Erlang/OTP 24)'
+
+      - name: Test that Erlang can start and has (major) expected version
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep 'Erlang/OTP 22'
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
         run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep 'v14.16.1'
       
       - name: Test that Elixir can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep 'Elixir 1.12.0 (compiled with Erlang/OTP 24)'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep 'Elixir 1.12.2 (compiled with Erlang/OTP 24)'
 
       - name: Test that Erlang can start and has (major) expected version
         run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep 'Erlang/OTP 22'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
+  TEST_EXPECTED_NODE_OUTPUT: "v14.16.1"
+  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.12.2 (compiled with Erlang/OTP 24)"
+  TEST_EXPECTED_ERLANG_OUTPUT: "Erlang/OTP 24"
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -57,13 +60,13 @@ jobs:
 
       # NOTE: the following tests rely on grep exit code (0 if match found)
       - name: Test that Node can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep 'v14.16.1'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep '${{ env.TEST_EXPECTED_NODE_OUTPUT }}'
       
       - name: Test that Elixir can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep 'Elixir 1.12.2 (compiled with Erlang/OTP 24)'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep '$${ env.TEST_EXPECTED_ELIXIR_OUTPUT }}'
 
       - name: Test that Erlang can start and has (major) expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep 'Erlang/OTP 24'
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep '$${ env.TEST_EXPECTED_ERLANG_OUTPUT }}'
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build and export to Docker
         uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
         with:
-          context: .
+          context: transport-site
           # "load: true" apparently exports the image on the client (no external push),
           # which is useful for testing it before any push.
           # see https://github.com/docker/build-push-action

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,10 +63,10 @@ jobs:
         run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version' | grep ${{ env.TEST_EXPECTED_NODE_OUTPUT }}
       
       - name: Test that Elixir can start and has expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep $${ env.TEST_EXPECTED_ELIXIR_OUTPUT }}
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep ${ env.TEST_EXPECTED_ELIXIR_OUTPUT }}
 
       - name: Test that Erlang can start and has (major) expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep $${ env.TEST_EXPECTED_ERLANG_OUTPUT }}
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep ${ env.TEST_EXPECTED_ERLANG_OUTPUT }}
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Test
         run: |
           # TODO: assert 
-          docker run -it --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version'
-          docker run -it --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version'
-          docker run -it --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
+          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'node --version'
+          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version'
+          docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -18,13 +18,13 @@ FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris
-RUN apt-get install -y tzdata
 
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     libtool \
-    git
+    git \
+    tzdata
 
 ENV NVM_VERSION v0.29.0
 ENV NODE_VERSION 14.16.1

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -18,13 +18,13 @@ FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris
+RUN apt-get install -y tzdata
 
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     libtool \
-    git \
-    tzdata
+    git
 
 ENV NVM_VERSION v0.29.0
 ENV NODE_VERSION 14.16.1


### PR DESCRIPTION
Deux points dans cette PR :

### Correction installation `tzdata`

`tzdata` ne pouvait pas être installé car il manquait un `apt-get update`.

Je déplace l'installation après le `update` existant (cf #31 pour la remontée d'origine).

### Début d'automatisation sur la construction de l'image Docker

Cf #30, les builds Docker via Docker Hub ont été historiquement compliquées (pour partie du fait de la taille de l'organisation, du système de délégation de droits pas suffisamment poussé, et aussi de bugs dans l'UX).

Les travaux précédemment réalisés sur https://github.com/etalab/transport-tools ont permis de défricher le fait de builder et publier une image via GitHub action et en direction du GitHub Container registry, et de voir que ça se passait bien.

Du coup cette PR ajoute une build Docker de l'image, avec 3 tests qui vérifient simplement que node/elixir/erlang sont installés et à la bonne version (uniquement version majeure pour Erlang), de façon à bloquer une PR ou une build.

Comment cela fonctionne : une image de "test" est buildée en local, dans le container action, puis des commandes sont lancées dessus.

Aucune publication n'est faite à ce stade, mais j'ai mis des notes pour y aller après.

Il faudra réfléchir au workflow souhaité.

Ce travail va aider à 1/ éviter les erreurs en local spécifiques à un développeur (encore la semaine dernière) et 2/ automatiser pour disposer de patchs sécurité plus fréquents.