### PR TITLE
[DO NOT MERGE] Mises à jour techniques (Elixir, Erlang, NVM, NodeJS)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ env:
   TEST_TAG: ${{ github.repository }}:test
   TEST_EXPECTED_NODE_OUTPUT: "v16.13.1"
   TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.13.1 (compiled with Erlang/OTP 24)"
-  TEST_EXPECTED_ERLANG_OUTPUT: "Erlang/OTP 24"
+  TEST_EXPECTED_ERLANG_OUTPUT: "24.2"
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Test that Elixir can start and has expected version
         run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c 'elixir --version' | grep '${{ env.TEST_EXPECTED_ELIXIR_OUTPUT }}'
 
-      - name: Test that Erlang can start and has (major) expected version
-        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'" | grep '${{ env.TEST_EXPECTED_ERLANG_OUTPUT }}'
+      - name: Test that Erlang can start and has expected version (major + minor + optional revision number)
+        run: docker run --rm ${{ env.TEST_TAG }} /bin/bash -c "erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), io:fwrite(Version), halt().' -noshell" | grep '${{ env.TEST_EXPECTED_ERLANG_OUTPUT }}'
 
       # TODO: handle testing then publication using:
       # - https://github.com/etalab/transport-ops/issues/30

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
   TEST_EXPECTED_NODE_OUTPUT: "v16.13.1"
-  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.12.2 (compiled with Erlang/OTP 24)"
+  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.13.1 (compiled with Erlang/OTP 24)"
   TEST_EXPECTED_ERLANG_OUTPUT: "Erlang/OTP 24"
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
-  TEST_EXPECTED_NODE_OUTPUT: "v14.16.1"
+  TEST_EXPECTED_NODE_OUTPUT: "v16.13.1"
   TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.12.2 (compiled with Erlang/OTP 24)"
   TEST_EXPECTED_ERLANG_OUTPUT: "Erlang/OTP 24"
 jobs:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ docker build transport-site --no-cache -t $IMAGE_NAME
 ```
 docker run -it --rm $IMAGE_NAME /bin/bash -c 'node --version'
 docker run -it --rm $IMAGE_NAME /bin/bash -c 'elixir --version'
+# only major
 docker run -it --rm $IMAGE_NAME /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"
+# full version (https://stackoverflow.com/a/34326368)
+docker run -it --rm $IMAGE_NME /bin/bash -c "erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), \"releases\", erlang:system_info(otp_release), \"OTP_VERSION\"])), io:fwrite(Version), halt().' -noshell"
 ```
 
 * Read the [docker push documentation](https://docs.docker.com/engine/reference/commandline/push/)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ As a work-around for [#17](https://github.com/etalab/transport-ops/issues/17):
 ```
 IMAGE_VERSION=$(rake get_image_version)
 IMAGE_NAME=betagouv/transport:$IMAGE_VERSION
-docker build transport-site --no-cache -t $IMAGE_NAME
+docker build transport-site --no-cache -t $IMAGE_NAME --progress=plain
 ```
 
 * Carefully verify the versions (this will be translated into a testing script later):
@@ -76,7 +76,7 @@ Before creating a tag, the following commands can be used to verify the versions
 
 ```
 cd transport-site
-docker build . -t test:latest
+docker build . -t test:latest --progress=plain
 docker run -it --rm test:latest /bin/bash -c 'node --version'
 docker run -it --rm test:latest /bin/bash -c 'elixir --version'
 docker run -it --rm test:latest /bin/bash -c "erl -noshell -eval 'erlang:display(erlang:system_info(system_version))' -eval 'init:stop()'"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 task :get_image_version do
   version = IO.read("transport-site/Dockerfile")[/FROM (hexpm\/elixir.*)/, 1]
   version = version.gsub('hexpm/elixir:','elixir-')
-  fail "Unexpected FROM format, script must be verified" unless version =~ /\Aelixir\-[^\-]+\-erlang\-[^\-]+\-alpine\-[^\-]+\z/
+  fail "Unexpected FROM value (got #{version}), script must be adapted?" unless version =~ /\Aelixir\-[^\-]+\-erlang\-[^\-]+\-ubuntu\-focal\-[^\-]+\z/
   puts version
 end

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -33,6 +33,22 @@ RUN apt-get update && apt-get install -y \
     git \
     tzdata
 
+# Helps bump the output of /etc/os-release from says "Ubuntu 24.04.2 LTS" to "... 24.04.3"
+#
+# The source image (hex) is itself based on a ubuntu image whose
+# packages are not necessarily up-to-date all the time. We want to
+# upgrade and ensure we are as up-to-date as possible.
+# Note that the kernel itself cannot be upgraded here apparently
+# (https://stackoverflow.com/a/66413248)
+# 
+# See https://github.com/etalab/transport_deploy/issues/46 for more context
+RUN apt-get upgrade -y
+
+# debugging information
+RUN uname --all
+RUN cat /etc/os-release
+RUN cat /etc/lsb-release
+
 ENV NVM_VERSION v0.39.1
 ENV NODE_VERSION 16.13.1
 ENV NVM_DIR $HOME/.nvm

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
     tzdata
 
 ENV NVM_VERSION v0.39.1
-ENV NODE_VERSION 14.16.1
+ENV NODE_VERSION 16.13.1
 ENV NVM_DIR $HOME/.nvm
 
 # Install NVM

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
     git \
     tzdata
 
-ENV NVM_VERSION v0.29.0
+ENV NVM_VERSION v0.39.1
 ENV NODE_VERSION 14.16.1
 ENV NVM_DIR $HOME/.nvm
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,4 +1,7 @@
-# We leverage the base images published by hexpm.
+# We are interested in the binaries compiled on that container:
+FROM ghcr.io/etalab/transport-tools:master as transport-tools
+
+# We leverage the base images published by hexpm at:
 #
 # https://hub.docker.com/r/hexpm/elixir
 #
@@ -10,10 +13,10 @@
 # - https://github.com/elixir-lang/elixir/releases
 # - https://github.com/erlang/otp/releases
 #
-
-# We are interested in the binaries compiled on that container:
-FROM ghcr.io/etalab/transport-tools:master as transport-tools
-
+#
+# So again, to upgrade this, check out : 
+#
+# https://hub.docker.com/r/hexpm/elixir
 FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -33,6 +33,8 @@ ENV NVM_VERSION v0.39.1
 ENV NODE_VERSION 16.13.1
 ENV NVM_DIR $HOME/.nvm
 
+RUN mkdir $NVM_DIR
+
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -17,7 +17,7 @@ FROM ghcr.io/etalab/transport-tools:master as transport-tools
 # So again, to upgrade this, check out : 
 #
 # https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
+FROM hexpm/elixir:1.13.1-erlang-24.2-ubuntu-focal-20210325
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -5,6 +5,10 @@ FROM ghcr.io/etalab/transport-tools:master as transport-tools
 #
 # https://hub.docker.com/r/hexpm/elixir
 #
+# Which are built via:
+#
+# https://github.com/hexpm/bob#docker-images
+# 
 # They provide the ability to decouple Elixir version
 # and OTP version, which is a nice feature for
 # incremental/decoupled upgrades.


### PR DESCRIPTION
(⚠️ pas encore terminé!)

Dans cette PR, de nombreuses mises à jour, et aussi des améliorations sur la build, le test, et un peu la sécurité.

L'acceptation de cette PR ne modifiera pas la version utilisée dans l'application, elle permettra simplement que je prépare une release de l'image de départ, que je pousserai par ailleurs sur Docker après avoir créé une release.

Ca veut dire qu'on contrôle le timing sans souci.

### Améliorations de la build

- Incorporation d'un `apt-get upgrade` pour mettre à jour ce qui peut l'être dans la partie Ubuntu. C'é'tait utile en pratique. Voir https://github.com/etalab/transport_deploy/issues/46 pour plus de contexte.
- Modification du test de la version OTP, car le précédent ne permettait que de distinguer sur la version majeure. On a à présent un test sur la version complète.

### Mises à jour

- Mise à jour de Elixir de 1.12.2 à 1.13.1 (avec `Map.filter/2` 🥳). Pour les changements, voir dans l'ordre:
  - https://github.com/elixir-lang/elixir/releases/tag/v1.12.3
  - https://github.com/elixir-lang/elixir/releases/tag/v1.13.0
  - https://github.com/elixir-lang/elixir/releases/tag/v1.13.1
- Mise à jour de OTP 24.0.4 à 24.2. Pour les changements (via https://erlang.org/download/otp_versions_tree.html):
  - https://github.com/erlang/otp/releases/tag/OTP-24.0.5
  - https://github.com/erlang/otp/releases/tag/OTP-24.0.6
  - https://github.com/erlang/otp/releases/tag/OTP-24.1
  - https://github.com/erlang/otp/releases/tag/OTP-24.1.1
  - https://github.com/erlang/otp/releases/tag/OTP-24.1.2
  - https://github.com/erlang/otp/releases/tag/OTP-24.1.3
  - https://github.com/erlang/otp/releases/tag/OTP-24.1.4
  - https://github.com/erlang/otp/releases/tag/OTP-24.1.5
  - https://github.com/erlang/otp/releases/tag/OTP-24.1.6
  - https://github.com/erlang/otp/releases/tag/OTP-24.1.7
  - https://github.com/erlang/otp/releases/tag/OTP-24.2
- Mise à jour de NodeJS de v14.16.1 à v16.13.1 (la [version LTS](https://nodejs.org/en/) actuelle). Trop de changements pour les lister, on verra si la build passe sur l'application, il faudra peut-être au pire faire quelques mises à jour de packages là bas (https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#16.13.1).
- Mise à jour de NVM (node version manager) de v0.29.0 (millésime [2015](https://github.com/nvm-sh/nvm/releases/tag/v0.29.0) 🥲) à v0.39.1 (voir [changes](https://github.com/nvm-sh/nvm/releases)). Le seul vrai souci détecté est que j'ai du créer à la main `~/.nvm` sinon ça ne marchait plus.