### PR TITLE
Ajout convertisseur GTFS vers NeTEx

### DIFF
--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -52,3 +52,6 @@ COPY --from=transport-tools /usr/local/bin/gtfs-geojson ./transport-tools
 RUN chmod +x /transport-tools/gtfs-geojson
 # quick check to verify binary dependencies are matched
 RUN /transport-tools/gtfs-geojson --help
+
+COPY --from=transport-tools /usr/local/bin/gtfs2netexfr ./transport-tools
+RUN /transport-tools/gtfs2netexfr --help

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -54,4 +54,8 @@ RUN chmod +x /transport-tools/gtfs-geojson
 RUN /transport-tools/gtfs-geojson --help
 
 COPY --from=transport-tools /usr/local/bin/gtfs2netexfr ./transport-tools
+# hackish - see https://github.com/etalab/transport-tools/blob/master/Dockerfile#L56
+RUN apt-get update
+RUN apt-get -y install libtiff5 libcurl3-nss
+COPY --from=transport-tools /usr/lib/libproj.* /usr/lib
 RUN /transport-tools/gtfs2netexfr --help

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -50,3 +50,5 @@ RUN mkdir /transport-tools
 
 COPY --from=transport-tools /usr/local/bin/gtfs-geojson ./transport-tools
 RUN chmod +x /transport-tools/gtfs-geojson
+# quick check to verify binary dependencies are matched
+RUN /transport-tools/gtfs-geojson --help


### PR DESCRIPTION
Cette PR rend disponible une première version du convertisseur GTFS vers NeTEx:
- Le binaire est lancé dans le Dockerfile une fois pour vérifier qu'il démarre (utile pour détecter les dépendances manquantes ) ; c'est pas 100% proof mais c'est déjà une belle amélioration sur les livraisons précédentes
- Ca utilise le même "hack" que je devrai nettoyer plus tard concernant l'installation de la librairie proj (voir https://github.com/etalab/transport-tools/pull/9 et https://github.com/etalab/transport_deploy/issues/47)
- Je vais aller publier l'image Docker ensuite, mais avec un nom différent, pour qu'on conserve l'ancienne en production, le temps de voir s'il n'y a pas d'effets de bord.
- Je temporise sur #30 (je souhaite bouger les images Docker chez GitHub) pour l'instant, mais le bon moment se rapproche (donc je vais publier à la main pour l'instant)