### PR TITLE
Gel de la version de transport-tools

### DIFF
--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -12,7 +12,7 @@
 #
 
 # We are interested in the binaries compiled on that container:
-FROM ghcr.io/etalab/transport-tools:master as transport-tools
+FROM ghcr.io/etalab/transport-tools:v1.0.1 as transport-tools
 
 FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
 


### PR DESCRIPTION
Suite à:
- https://github.com/etalab/transport-tools/pull/11
- https://github.com/etalab/transport-tools/pull/12

On peut de façon fiable automatiser les publications d'image ici dès qu'une release est faite.

Dans cette PR:
- Je freeze la version de `transport-tools` pour avoir le convertisseur GTFS vers NeTEx introduit dans #34