### PR TITLE
Suite de la copie de proj

### DIFF
--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -58,4 +58,5 @@ COPY --from=transport-tools /usr/local/bin/gtfs2netexfr ./transport-tools
 RUN apt-get update
 RUN apt-get -y install libtiff5 libcurl3-nss
 COPY --from=transport-tools /usr/lib/libproj.* /usr/lib
+COPY --from=transport-tools /usr/share/proj/ /usr/share/proj/
 RUN /transport-tools/gtfs2netexfr --help

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -12,7 +12,7 @@
 #
 
 # We are interested in the binaries compiled on that container:
-FROM ghcr.io/etalab/transport-tools:v1.0.1 as transport-tools
+FROM ghcr.io/etalab/transport-tools:v1.0.2-test-proj as transport-tools
 
 FROM hexpm/elixir:1.12.2-erlang-24.0.4-ubuntu-focal-20210325
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -58,5 +58,6 @@ COPY --from=transport-tools /usr/local/bin/gtfs2netexfr ./transport-tools
 RUN apt-get update
 RUN apt-get -y install libtiff5 libcurl3-nss
 COPY --from=transport-tools /usr/lib/libproj.* /usr/lib
+RUN mkdir /usr/share/proj/
 COPY --from=transport-tools /usr/share/proj/ /usr/share/proj/
 RUN /transport-tools/gtfs2netexfr --help


### PR DESCRIPTION
Après avoir copié du container Kisio vers celui de transport tools (https://github.com/etalab/transport-tools/pull/13), on copie le même dossier de transport-tools vers transport-ops.