### PR TITLE
Mises à jour techniques (Elixir 14, ...)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
-  TEST_EXPECTED_NODE_OUTPUT: "v16.15.0"
+  TEST_EXPECTED_NODE_OUTPUT: "v16.17.1"
   TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.13.4 (compiled with Erlang/OTP 24)"
   TEST_EXPECTED_ERLANG_OUTPUT: "24.3.4"
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
   TEST_EXPECTED_NODE_OUTPUT: "v16.17.1"
-  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.13.4 (compiled with Erlang/OTP 24)"
-  TEST_EXPECTED_ERLANG_OUTPUT: "24.3.4"
+  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.14.0 (compiled with Erlang/OTP 24)"
+  TEST_EXPECTED_ERLANG_OUTPUT: "24.3.4.5"
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -70,7 +70,7 @@ RUN cat /etc/os-release
 RUN cat /etc/lsb-release
 
 ENV NVM_VERSION v0.39.1
-ENV NODE_VERSION 16.15.0
+ENV NODE_VERSION 16.17.1
 ENV NVM_DIR $HOME/.nvm
 
 RUN mkdir $NVM_DIR

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -22,7 +22,7 @@ FROM ghcr.io/etalab/transport-tools:v1.0.3 as transport-tools
 # So again, to upgrade this, check out : 
 #
 # https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.13.4-erlang-24.3.4-ubuntu-focal-20211006
+FROM hexpm/elixir:1.14.0-erlang-24.3.4.5-ubuntu-focal-20211006
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -107,5 +107,5 @@ COPY --from=transport-tools /usr/share/proj/ /usr/share/proj/
 RUN /transport-tools/gtfs2netexfr --help
 COPY --from=transport-tools /usr/local/bin/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar ./transport-tools
 RUN java -jar /transport-tools/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar 2>&1 | grep "For batch mode you must provide a path and file name to GTFS data"
-COPY --from=transport-tools /usr/local/bin/gtfs-validator-v3.0.0_cli.jar ./transport-tools
-RUN java -jar /transport-tools/gtfs-validator-v3.0.0_cli.jar --help | grep "Location of the input GTFS ZIP"
+COPY --from=transport-tools /usr/local/bin/gtfs-validator-3.1.1-cli.jar ./transport-tools
+RUN java -jar /transport-tools/gtfs-validator-3.1.1-cli.jar --help | grep "Location of the input GTFS ZIP"

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,6 +1,5 @@
 # We are interested in the binaries compiled on that container:
-# TODO: bump to v1.0.4 once published
-FROM ghcr.io/etalab/transport-tools:v1.0.3 as transport-tools
+FROM ghcr.io/etalab/transport-tools:v1.0.4 as transport-tools
 
 # We leverage the base images published by hexpm at:
 #

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,4 +1,5 @@
 # We are interested in the binaries compiled on that container:
+# TODO: bump to v1.0.4 once published
 FROM ghcr.io/etalab/transport-tools:v1.0.3 as transport-tools
 
 # We leverage the base images published by hexpm at:


### PR DESCRIPTION
Dans cette PR:
- Passage à Elixir 1.14 ([support de dbg](https://elixir-lang.org/blog/2022/09/01/elixir-v1-14-0-released/), et également requis pour profiter de + d'aide au compile time avec [LiveView 0.18.0](https://github.com/phoenixframework/phoenix_live_view/blob/master/CHANGELOG.md#0180-2022-09-20))
- Mise à jour de `transport-tools`, avec en particulier les mises à jour du convertisseur GTFS vers GeoJSON, NETeX, et le passage au fork MobilityData du validateur GTFS-RT (https://github.com/etalab/transport-tools/pull/18)
- Mise à jour mineure de NodeJS
- Mise à jour mineure de Erlang
- Et patchs sécurité pour l'OS, également