### PR TITLE
Mise à jour Elixir (1.15), NVM, Node

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,8 +19,8 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
-  TEST_EXPECTED_NODE_OUTPUT: "v18.16.1"
-  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.14.5 (compiled with Erlang/OTP 24)"
+  TEST_EXPECTED_NODE_OUTPUT: "v18.17.1"
+  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.15.5 (compiled with Erlang/OTP 24)"
   TEST_EXPECTED_ERLANG_OUTPUT: "24.3.4.13"
 jobs:
   build-and-push-image:

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -21,7 +21,7 @@ FROM ghcr.io/etalab/transport-tools:v1.0.7 as transport-tools
 # So again, to upgrade this, check out : 
 #
 # https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.14.5-erlang-24.3.4.13-ubuntu-focal-20230126
+FROM hexpm/elixir:1.15.5-erlang-24.3.4.13-ubuntu-focal-20230126
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris
@@ -72,8 +72,8 @@ RUN uname --all
 RUN cat /etc/os-release
 RUN cat /etc/lsb-release
 
-ENV NVM_VERSION v0.39.3
-ENV NODE_VERSION 18.16.1
+ENV NVM_VERSION v0.39.5
+ENV NODE_VERSION 18.17.1
 ENV NVM_DIR $HOME/.nvm
 
 RUN mkdir $NVM_DIR


### PR DESCRIPTION
Mises à jour:
- Elixir 1.14.5 -> 1.15.5
- NVM 0.39.3 -> 0.39.5
- NodeJS 18.16.1 -> 18.17.1

On reste sur OTP 24 pour le moment.