### PR TITLE
Mises à jour Elixir (1.17), OTP (27), NodeJS

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,8 +20,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
   TEST_EXPECTED_NODE_OUTPUT: "v20.11.1"
-  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.16.2 (compiled with Erlang/OTP 25)"
-  TEST_EXPECTED_ERLANG_OUTPUT: "25.3.2.10"
+  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.17.2 (compiled with Erlang/OTP 27)"
+  TEST_EXPECTED_ERLANG_OUTPUT: "27.0.1"
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
-  TEST_EXPECTED_NODE_OUTPUT: "v20.11.1"
+  TEST_EXPECTED_NODE_OUTPUT: "v20.17.0"
   TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.17.2 (compiled with Erlang/OTP 27)"
   TEST_EXPECTED_ERLANG_OUTPUT: "27.0.1"
 jobs:

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -72,7 +72,7 @@ RUN uname --all
 RUN cat /etc/os-release
 RUN cat /etc/lsb-release
 
-ENV NVM_VERSION=v0.39.7
+ENV NVM_VERSION=v0.40.1
 ENV NODE_VERSION=20.11.1
 ENV NVM_DIR=$HOME/.nvm
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -73,7 +73,7 @@ RUN cat /etc/os-release
 RUN cat /etc/lsb-release
 
 ENV NVM_VERSION=v0.40.1
-ENV NODE_VERSION=20.11.1
+ENV NODE_VERSION=20.17.0
 ENV NVM_DIR=$HOME/.nvm
 
 RUN mkdir $NVM_DIR

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -72,9 +72,9 @@ RUN uname --all
 RUN cat /etc/os-release
 RUN cat /etc/lsb-release
 
-ENV NVM_VERSION v0.39.7
-ENV NODE_VERSION 20.11.1
-ENV NVM_DIR $HOME/.nvm
+ENV NVM_VERSION=v0.39.7
+ENV NODE_VERSION=20.11.1
+ENV NVM_DIR=$HOME/.nvm
 
 RUN mkdir $NVM_DIR
 
@@ -85,8 +85,8 @@ RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/ins
 RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION
 
 # add to path
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+ENV NODE_PATH=$NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 RUN npm install -g yarn
 

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -1,5 +1,5 @@
 # We are interested in the binaries compiled on that container:
-FROM ghcr.io/etalab/transport-tools:v1.0.7 as transport-tools
+FROM ghcr.io/etalab/transport-tools:v1.0.7 AS transport-tools
 
 # We leverage the base images published by hexpm at:
 #

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -21,7 +21,7 @@ FROM ghcr.io/etalab/transport-tools:v1.0.7 as transport-tools
 # So again, to upgrade this, check out : 
 #
 # https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.16.2-erlang-25.3.2.10-ubuntu-focal-20240216
+FROM hexpm/elixir:1.17.2-erlang-27.0.1-ubuntu-focal-20240530
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris


### PR DESCRIPTION
Mises à jour de :
- NodeJS de v20.11.1 à v20.17.0
- Elixir de 1.16.2 à 1.17.2
- Erlang OTP de 25.3.2.10 à 27.0.1
- NVM de v0.39.7 à v0.40.1

Et quelques correctifs (deprecation warnings Docker).

Je laisse de côté des upgrades plus "métier" (validateurs) pour ne pas coupler les sujets.