### PR TITLE
Correctif régression Rakefile regression (as -> AS)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,8 @@ task :get_image_version do
   dockerfile_content = IO.read("transport-site/Dockerfile")
   version = dockerfile_content[/FROM (hexpm\/elixir.*)/, 1]
   version = version.gsub('hexpm/elixir:','elixir-')
-  tools_version = dockerfile_content[/transport-tools:v(\d+\.\d+\.\d+) as transport-tools/, 1]
-  fail "Unexpected FROM value (got #{version}), script must be adapted?" unless version =~ /\Aelixir\-[^\-]+\-erlang\-[^\-]+\-ubuntu\-focal\-[^\-]+\z/
+  tools_version = dockerfile_content[/transport-tools:v(\d+\.\d+\.\d+) as transport-tools/i, 1]
+  fail "Unexpected FROM value (got #{version.inspect}), script must be adapted?" unless version =~ /\Aelixir\-[^\-]+\-erlang\-[^\-]+\-ubuntu\-focal\-[^\-]+\z/
+  fail "Unexpected tools_version value (got #{tools_version.inspect}), script must be adapted?" unless tools_version =~ /\A\d\.\d\.\d\z/
   puts version + "-transport-tools-" + tools_version
 end


### PR DESCRIPTION
Mes mises à jour techniques faites ici:
- #59 
- et en particulier https://github.com/etalab/transport-ops/pull/59/files#diff-8a1e1b21bfa3fb6fb0121ed7583d46e3a7f4d26081ddcb0b80ef5833efbecb62L2-R2

ont cassé le script Rake qui sert à générer de façon automatisée le nom de la release (que j'ai ensuite utilisé pour releaser https://github.com/etalab/transport-ops/releases/tag/elixir-1.17.2-erlang-27.0.1-ubuntu-focal-20240530-transport-tools-1.0.7).