### PR TITLE
[WIP] Elixir v1.20

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ env:
   TEST_TAG: ${{ github.repository }}:test
   TEST_EXPECTED_NODE_OUTPUT: "v24.18.0"
   TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.20.2 (compiled with Erlang/OTP 27)"
-  TEST_EXPECTED_ERLANG_OUTPUT: "27.3.4.13"
+  TEST_EXPECTED_ERLANG_OUTPUT: "27.3.4.14"
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
-  TEST_EXPECTED_NODE_OUTPUT: "v22.16.0"
+  TEST_EXPECTED_NODE_OUTPUT: "v24.18.0"
   TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.20.2 (compiled with Erlang/OTP 27)"
   TEST_EXPECTED_ERLANG_OUTPUT: "27.3.4.13"
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,8 +20,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
   TEST_EXPECTED_NODE_OUTPUT: "v22.16.0"
-  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.19.4 (compiled with Erlang/OTP 27)"
-  TEST_EXPECTED_ERLANG_OUTPUT: "27.3.4.1"
+  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.20.0 (compiled with Erlang/OTP 27)"
+  TEST_EXPECTED_ERLANG_OUTPUT: "27.3.4.12"
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,8 +20,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: ${{ github.repository }}:test
   TEST_EXPECTED_NODE_OUTPUT: "v22.16.0"
-  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.20.0 (compiled with Erlang/OTP 27)"
-  TEST_EXPECTED_ERLANG_OUTPUT: "27.3.4.12"
+  TEST_EXPECTED_ELIXIR_OUTPUT: "Elixir 1.20.2 (compiled with Erlang/OTP 27)"
+  TEST_EXPECTED_ERLANG_OUTPUT: "27.3.4.13"
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -21,7 +21,7 @@ FROM ghcr.io/etalab/transport-tools:v2.0.0 AS transport-tools
 # So again, to upgrade this, check out : 
 #
 # https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.20.2-erlang-27.3.4.13-ubuntu-noble-20260509.1
+FROM hexpm/elixir:1.20.2-erlang-27.3.4.14-ubuntu-noble-20260610
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -72,8 +72,8 @@ RUN uname --all
 RUN cat /etc/os-release
 RUN cat /etc/lsb-release
 
-ENV NVM_VERSION=v0.40.3
-ENV NODE_VERSION=22.16.0
+ENV NVM_VERSION=v0.40.5
+ENV NODE_VERSION=24.18.0
 ENV NVM_DIR=/root/.nvm
 
 RUN mkdir $NVM_DIR

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -21,7 +21,7 @@ FROM ghcr.io/etalab/transport-tools:v2.0.0 AS transport-tools
 # So again, to upgrade this, check out : 
 #
 # https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.20.0-erlang-27.3.4.12-ubuntu-noble-20251013
+FROM hexpm/elixir:1.20.2-erlang-27.3.4.13-ubuntu-noble-20260509.1
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris

--- a/transport-site/Dockerfile
+++ b/transport-site/Dockerfile
@@ -21,7 +21,7 @@ FROM ghcr.io/etalab/transport-tools:v2.0.0 AS transport-tools
 # So again, to upgrade this, check out : 
 #
 # https://hub.docker.com/r/hexpm/elixir
-FROM hexpm/elixir:1.19.4-erlang-27.3.4.1-ubuntu-noble-20251013
+FROM hexpm/elixir:1.20.0-erlang-27.3.4.12-ubuntu-noble-20251013
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris


### PR DESCRIPTION
Quelques notes:
- WIP et ne "docker build" pas bien en local, je vais vérifier pourquoi (car c'est utile pour débugger)
- Je vais sur Elixir v1.20.x pour meilleur typage et autres bénéfices
- Je reste sur OTP 27 par contre, car OTP 28 et OTP 29 nécessiteront + de soin

### Étapes réalisées et prévues

- [x] Déterminer la cible pour OTP (-> on reste sur OTP 27 cf ci-dessus)
- [x] Bumper Elixir
- [x] Bumper OTP au dernier 27.3.x
- [x] Corriger les tests
- [x] Mettre à jour NodeJS et NVM tant que j'y suis
- [ ] Regarder un peu le reste (tools)
- [ ] Tater le terrain (pre-merge de la présente PR) sur `transport-site` (https://github.com/transportdatagouvfr/ops/pkgs/container/ops/992089702?tag=pr-66)